### PR TITLE
[REF] partner_event: avoid execution post_init_hook - i#3000

### DIFF
--- a/partner_event/__manifest__.py
+++ b/partner_event/__manifest__.py
@@ -25,6 +25,5 @@
         "wizard/res_partner_register_event_view.xml",
     ],
     "maintainers": ["yajo", "rafaelbn"],
-    "post_init_hook": "post_init_hook",
     "installable": True,
 }


### PR DESCRIPTION
In IRCc the partners from attendees were already created. Also, the method is taking a lot of time, so this removes the line to avoid the execution.

Related: https://gitlab.com/ircanada/ircodoo/-/issues/3000